### PR TITLE
Accept '+' for int parameters

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,13 +3,14 @@
 use crate::tuple_concat::TupleConcat;
 
 /// ```
+///  use at_commands::parser::CommandParser;
 ///  let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:654,\"true\",-65154\r\nOK\r\n")
 ///     .expect_identifier(b"+SYSGPIOREAD:")
 ///     .expect_int_parameter()
 ///     .expect_string_parameter()
 ///     .expect_int_parameter()
 ///     .expect_identifier(b"\r\nOK\r\n")
-///     .finish() 
+///     .finish()
 ///     .unwrap();
 /// ```
 #[must_use]
@@ -64,7 +65,9 @@ impl<'a, D> CommandParser<'a, D> {
                 .map(|buffer| {
                     buffer
                         .iter()
-                        .take_while(|byte| byte.is_ascii_digit() || **byte == b'-' || **byte == b'+')
+                        .take_while(|byte| {
+                            byte.is_ascii_digit() || **byte == b'-' || **byte == b'+'
+                        })
                         .count()
                 })
                 .unwrap_or(self.buffer.len())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -144,6 +144,7 @@ impl<'a, D: TupleConcat<i32>> CommandParser<'a, D> {
             };
         }
 
+        // Skip the leading '+'
         let int_slice = if int_slice[0] == b'+' {
             &int_slice[1..]
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -64,7 +64,7 @@ impl<'a, D> CommandParser<'a, D> {
                 .map(|buffer| {
                     buffer
                         .iter()
-                        .take_while(|byte| byte.is_ascii_digit() || **byte == b'-')
+                        .take_while(|byte| byte.is_ascii_digit() || **byte == b'-' || **byte == b'+')
                         .count()
                 })
                 .unwrap_or(self.buffer.len())
@@ -140,6 +140,12 @@ impl<'a, D: TupleConcat<i32>> CommandParser<'a, D> {
                 data: self.data.tup_cat(0),
             };
         }
+
+        let int_slice = if int_slice[0] == b'+' {
+            &int_slice[1..]
+        } else {
+            int_slice
+        };
 
         // Parse the int
         let parsed_int = crate::formatter::parse_int(int_slice);
@@ -245,5 +251,17 @@ mod tests {
         assert_eq!(x, 654);
         assert_eq!(y, "true");
         assert_eq!(z, -65154);
+    }
+
+    #[test]
+    fn test_positive_int_param() {
+        let (x,) = CommandParser::parse(b"OK+RP:+20dBm\r\n")
+            .expect_identifier(b"OK+RP:")
+            .expect_int_parameter()
+            .expect_identifier(b"dBm\r\n")
+            .finish()
+            .unwrap();
+
+        assert_eq!(x, 20);
     }
 }

--- a/src/tuple_concat.rs
+++ b/src/tuple_concat.rs
@@ -65,34 +65,54 @@ impl<T0, T1, T2, T3, T4, T5, T6, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, 
 impl<T0, T1, T2, T3, T4, T5, T6, T7, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, T6, T7) {
     type Out = (T0, T1, T2, T3, T4, T5, T6, T7, C);
     fn tup_cat(self, c: C) -> Self::Out {
-        (self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, c)
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, c,
+        )
     }
 }
 
-impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, T6, T7, T8) {
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+{
     type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, C);
     fn tup_cat(self, c: C) -> Self::Out {
-        (self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, c)
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, c,
+        )
     }
 }
 
-impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) {
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
+{
     type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, C);
     fn tup_cat(self, c: C) -> Self::Out {
-        (self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9, c)
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9, c,
+        )
     }
 }
 
-impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) {
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+{
     type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, C);
     fn tup_cat(self, c: C) -> Self::Out {
-        (self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9, self.10, c)
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, c,
+        )
     }
 }
 
-impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, C> TupleConcat<C> for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) {
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+{
     type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, C);
     fn tup_cat(self, c: C) -> Self::Out {
-        (self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9, self.10, self.11, c)
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, self.11, c,
+        )
     }
 }

--- a/src/tuple_concat.rs
+++ b/src/tuple_concat.rs
@@ -1,5 +1,5 @@
 #![allow(unused_attributes)]
-#![rustfmt::skip]
+#[rustfmt::skip]
 
 pub trait TupleConcat<C> {
     type Out;


### PR DESCRIPTION
Hi,
I'm using at-commands for my hc-12 driver. This driver reports transmission power as dBm. This can be positive or negative. Negative works fine, but positive is reported as "+n". This patch adds support for parsing that number. Let me know if you see something I can improve upon :)