### PR TITLE
Support TupleConcat tuples up to 17 elements wide

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,7 +243,7 @@ impl<'a, D: TupleConcat<&'a str>> CommandParser<'a, D> {
 
         // Get the end index of the current parameter.
         let parameter_end = self.find_end_of_string_parameter();
-        if parameter_end == self.buffer.len() {
+        if parameter_end > self.buffer.len() {
             // We hit the end of the buffer.
             // The parameter is empty so it is always invalid.
             self.data_valid = false;
@@ -379,5 +379,18 @@ mod tests {
         assert_eq!(x, 654);
         assert_eq!(y, "true");
         assert_eq!(z, -65154);
+    }
+
+    #[test]
+    fn string_param_at_end() {
+        let (x, y) = CommandParser::parse(br#"+SYSGPIOREAD: 42, "param at end""#)
+            .expect_identifier(b"+SYSGPIOREAD:")
+            .expect_int_parameter()
+            .expect_string_parameter()
+            .finish()
+            .unwrap();
+
+        assert_eq!(x, 42);
+        assert_eq!(y, "param at end");
     }
 }

--- a/src/tuple_concat.rs
+++ b/src/tuple_concat.rs
@@ -115,3 +115,51 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, C> TupleConcat<C>
         )
     }
 }
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+{
+    type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, C);
+    fn tup_cat(self, c: C) -> Self::Out {
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, self.11, self.12, c,
+        )
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+{
+    type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, C);
+    fn tup_cat(self, c: C) -> Self::Out {
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, self.11, self.12, self.13, c,
+        )
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+{
+    type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, C);
+    fn tup_cat(self, c: C) -> Self::Out {
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, self.11, self.12, self.13, self.14, c,
+        )
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, C> TupleConcat<C>
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+{
+    type Out = (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, C);
+    fn tup_cat(self, c: C) -> Self::Out {
+        (
+            self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9,
+            self.10, self.11, self.12, self.13, self.14, self.15, c,
+        )
+    }
+}


### PR DESCRIPTION
Hi Dion. I'm using your lib for a small test tool (so thanks for that! 👍🏻). While doing so, I encountered two issues: one had to do with the limited 'width' of the returned tuple (while trying to parse this AT-response: `%XMONITOR: 1,"","","20408","7B71",7,20,"0090D90D",371,6400,51,27,"","11100000","11100000","01001001"`). So I went ahead and added some types to increase the width. Probably it would be nicer to implement this `TupleConcat` type with some macro.

Furthermore, I encountered what I think is a small bug, and has to do when parsing out the last string (i.e. using `.expect_string_parameter()`) on a given buffer. When there's no bytes after the last `"`, the segment is (wrongfully in my view) marked as invalid.