### PR TITLE
add support for optional parser parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Added optional parser parameters: [diondokter/at-commands#9](https://github.com/diondokter/at-commands/pull/9)
+
 ## [0.5.3] - 2022-09-11
 - More arguments are now supported: [diondokter/at-commands#6](https://github.com/diondokter/at-commands/pull/6)
 - Small bugfix for parsing string parameters that have no characters after it in the input string: [diondokter/at-commands#6](https://github.com/diondokter/at-commands/pull/6)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,6 +69,34 @@ impl<'a, D> CommandParser<'a, D> {
         self.trim_space()
     }
 
+    /// Tries reading an optional identifier.
+    pub fn expect_optional_identifier(mut self, identifier: &[u8]) -> Self {
+        // If we're already not valid, then quit
+        if !self.data_valid {
+            return self;
+        }
+
+        // empty identifier is always valid
+        if self.buffer[self.buffer_index..].len() == 0 {
+            return self;
+        }
+
+        if self.buffer[self.buffer_index..].len() < identifier.len() {
+            self.data_valid = false;
+            return self;
+        }
+
+        // Zip together the identifier and the buffer data. If all bytes are the same, the data is valid.
+        self.data_valid = self.buffer[self.buffer_index..]
+            .iter()
+            .zip(identifier)
+            .all(|(buffer, id)| *buffer == *id);
+        // Advance the index
+        self.buffer_index += identifier.len();
+
+        self.trim_space()
+    }
+
     /// Moves the internal buffer index over the next bit of space characters, if any
     fn trim_space(mut self) -> Self {
         // If we're already not valid, then quit
@@ -322,10 +350,186 @@ impl<'a, D: TupleConcat<&'a str>> CommandParser<'a, D> {
     }
 }
 
+//
+// Optional parameters
+//
+
+impl<'a, D: TupleConcat<Option<i32>>> CommandParser<'a, D> {
+    /// Tries reading an int parameter
+    pub fn expect_optional_int_parameter(mut self) -> CommandParser<'a, D::Out> {
+        // If we're already not valid, then quit
+        if !self.data_valid {
+            return CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            };
+        }
+
+        // Get the end index of the current parameter.
+        let parameter_end = self.find_end_of_int_parameter();
+        // Get the bytes in which the int should reside.
+        let int_slice = match self.buffer.get(self.buffer_index..parameter_end) {
+            None => {
+                return CommandParser {
+                    buffer: self.buffer,
+                    buffer_index: self.buffer_index,
+                    data_valid: self.data_valid,
+                    data: self.data.tup_cat(None),
+                };
+            }
+            Some(int_slice) => int_slice,
+        };
+        if int_slice.is_empty() {
+            // We probably hit the end of the buffer.
+            // The parameter is empty but as it is optional not invalid
+            // Advance the index to the character after the parameter separator (comma) if it's there.
+            self.buffer_index =
+            parameter_end + (self.buffer.get(parameter_end) == Some(&b',')) as usize;
+            return CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            };
+        }
+
+        // Skip the leading '+'
+        let int_slice = if int_slice[0] == b'+' {
+            &int_slice[1..]
+        } else {
+            int_slice
+        };
+
+        // Parse the int
+        let parsed_int = crate::formatter::parse_int(int_slice);
+
+        // Advance the index to the character after the parameter separator (comma) if it's there.
+        self.buffer_index =
+            parameter_end + (self.buffer.get(parameter_end) == Some(&b',')) as usize;
+        // If we've found an int, then the data may be valid and we allow the closure to set the result ok data.
+        if let Some(parameter_value) = parsed_int {
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(Some(parameter_value)),
+            }
+        } else {
+            self.data_valid = false;
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            }
+        }
+        .trim_space()
+    }
+}
+
+impl<'a, D: TupleConcat<Option<&'a str>>> CommandParser<'a, D> {
+    /// Tries reading a string parameter
+    pub fn expect_optional_string_parameter(mut self) -> CommandParser<'a, D::Out> {
+        // If we're already not valid, then quit
+        if !self.data_valid {
+            return CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            };
+        }
+
+        // Get the end index of the current parameter.
+        let parameter_end = self.find_end_of_string_parameter();
+        if parameter_end > self.buffer.len() {
+            // We hit the end of the buffer.
+            // The parameter is empty but as it is optional not invalid
+            return CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            };
+        }
+        // Get the bytes in which the string should reside.
+        let string_slice = &self.buffer[(self.buffer_index + 1)..(parameter_end - 1)];
+
+        let has_comma_after_parameter = if let Some(next_char) = self.buffer.get(parameter_end) {
+            *next_char == b','
+        } else {
+            false
+        };
+
+        // Advance the index to the character after the parameter separator.
+        self.buffer_index = parameter_end + has_comma_after_parameter as usize;
+        // If we've found a valid string, then the data may be valid and we allow the closure to set the result ok data.
+        if let Ok(parameter_value) = core::str::from_utf8(string_slice) {
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(Some(parameter_value)),
+            }
+        } else {
+            self.data_valid = false;
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            }
+        }
+        .trim_space()
+    }
+
+    /// Tries reading a non-parameter, non-quoted string
+    pub fn expect_optional_raw_string(mut self) -> CommandParser<'a, D::Out> {
+        // If we're already not valid, then quit
+        if !self.data_valid {
+            return CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            };
+        }
+
+        // Get the end index of the current string.
+        let end = self.find_end_of_raw_string();
+        // Get the bytes in which the string should reside.
+        let string_slice = &self.buffer[self.buffer_index..(end - 1)];
+
+        // Advance the index to the character after the string.
+        self.buffer_index = end - 1usize;
+
+        // If we've found a valid string, then the data may be valid and we allow the closure to set the result ok data.
+        if let Ok(parameter_value) = core::str::from_utf8(string_slice) {
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(Some(parameter_value)),
+            }
+        } else {
+            self.data_valid = false;
+            CommandParser {
+                buffer: self.buffer,
+                buffer_index: self.buffer_index,
+                data_valid: self.data_valid,
+                data: self.data.tup_cat(None),
+            }
+        }
+        .trim_space()
+    }
+}
+
 /// Error type for parsing
 ///
 /// The number is the index of up to where it was correctly parsed
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ParseError(usize);
 
@@ -389,4 +593,94 @@ mod tests {
         assert_eq!(x, 42);
         assert_eq!(y, "param at end");
     }
+
+    #[test]
+    fn test_optional_int_parameter_all_present() {
+        let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:654,\"true\",-65154\r\nOK\r\n")
+            .expect_identifier(b"+SYSGPIOREAD:")
+            .expect_optional_int_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_int_parameter()
+            .expect_identifier(b"\r\nOK\r\n")
+            .finish()
+            .unwrap();
+
+        assert_eq!(x, Some(654));
+        assert_eq!(y, Some("true"));
+        assert_eq!(z, Some(-65154));
+        
+    }
+
+    #[test]
+    fn test_optional_int_parameter_middle_not_present() {
+        let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:,\"true\"\r\nOK\r\n")
+            .expect_identifier(b"+SYSGPIOREAD:")
+            .expect_optional_int_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_int_parameter()
+            .expect_identifier(b"\r\nOK\r\n")
+            .finish()
+            .unwrap();
+
+        assert_eq!(x, None);
+        assert_eq!(y, Some("true"));
+        assert_eq!(z, None);
+    }
+
+    #[test]
+    fn test_optional_int_parameter_end_not_present() {
+        let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:654,\"true\",\r\nOK\r\n")
+            .expect_identifier(b"+SYSGPIOREAD:")
+            .expect_optional_int_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_identifier(b"\r\nOK\r\n")
+            .finish()
+            .unwrap();
+
+        assert_eq!(x, Some(654));
+        assert_eq!(y, Some("true"));
+        assert_eq!(z, None);
+    }
+
+    #[test]
+    fn test_optional_identifier() {
+        let r = CommandParser::parse(b"+SYSGPIOREAD:,\"true\"\r\nK\r\n")
+            .expect_identifier(b"+SYSGPIOREAD:")
+            .expect_optional_int_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_identifier(b"\r\nOK\r\n")
+            .finish();
+
+        assert_eq!(r, Err(ParseError(20)));
+
+        let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:,\"true\"\r\nOK\r\n")
+        .expect_identifier(b"+SYSGPIOREAD:")
+        .expect_optional_int_parameter()
+        .expect_optional_string_parameter()
+        .expect_optional_int_parameter()
+        .expect_optional_identifier(b"\r\nOK\r\n")
+        .finish()
+        .unwrap();
+
+        assert_eq!(x, None);
+        assert_eq!(y, Some("true"));
+        assert_eq!(z, None);
+
+        let (x, y, z) = CommandParser::parse(b"+SYSGPIOREAD:,\"true\"")
+        .expect_identifier(b"+SYSGPIOREAD:")
+        .expect_optional_int_parameter()
+        .expect_optional_string_parameter()
+        .expect_optional_int_parameter()
+        .expect_optional_identifier(b"\r\nOK\r\n")
+        .finish()
+        .unwrap();
+
+        assert_eq!(x, None);
+        assert_eq!(y, Some("true"));
+        assert_eq!(z, None);
+        
+    }
+
 }


### PR DESCRIPTION
This should be a discussion starter for an implementation for #7.
It is mostly a copy of the existing methods and tweaking them a bit.

I would also replace the implementation of the none optional counterparts with the optional ones and just wrap it with a None check.