### PR TITLE
Change from &str to AsRef<[u8]> in builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Added optional parser parameters: [diondokter/at-commands#9](https://github.com/diondokter/at-commands/pull/9)
+- Changed &str to AsRef<[u8]> in CommandBuilder methods: [diondokter/at-commands#10](https://github.com/diondokter/at-commands/pull/10)
 
 ## [0.5.3] - 2022-09-11
 - More arguments are now supported: [diondokter/at-commands#6](https://github.com/diondokter/at-commands/pull/6)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -150,8 +150,8 @@ impl<'a, ANY> CommandBuilder<'a, ANY> {
 
 impl<'a, N: Nameable> CommandBuilder<'a, Initialized<N>> {
     /// Set the name of the command.
-    pub fn named(mut self, name: &str) -> CommandBuilder<'a, N> {
-        self.try_append_data(name.as_bytes());
+    pub fn named<T: AsRef<[u8]>>(mut self, name: T) -> CommandBuilder<'a, N> {
+        self.try_append_data(name.as_ref());
         self.try_append_data(N::NAME_SUFFIX);
 
         CommandBuilder::<'a, N> {
@@ -175,9 +175,9 @@ impl<'a> CommandBuilder<'a, Set> {
     }
 
     /// Add a string parameter
-    pub fn with_string_parameter(mut self, value: &str) -> Self {
+    pub fn with_string_parameter<T: AsRef<[u8]>>(mut self, value: T) -> Self {
         self.try_append_data(b"\"");
-        self.try_append_data(value.as_bytes());
+        self.try_append_data(value.as_ref());
         self.try_append_data(b"\"");
         self.try_append_data(b",");
         self
@@ -192,7 +192,7 @@ impl<'a> CommandBuilder<'a, Set> {
     }
 
     /// Add an optional string parameter.
-    pub fn with_optional_string_parameter(self, value: Option<&str>) -> Self {
+    pub fn with_optional_string_parameter<T: AsRef<[u8]>>(self, value: Option<T>) -> Self {
         match value {
             None => self.with_empty_parameter(),
             Some(value) => self.with_string_parameter(value),


### PR DESCRIPTION
Changes from &str to AsRef in the CommandBuilder. For #8

Let me know if you want me to add a test case or have suggestions. 