### PR TITLE
Add a trim_whitespace convenience method

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -212,7 +212,7 @@ impl CommandBuilder<'_, Set> {
         self
     }
 
-    /// Add the given [value] to the array using the hex format for the bytes
+    /// Add the given value to the array using the hex format for the bytes
     pub fn with_rax_hex_parameter<T: AsRef<[u8]>>(mut self, value: T) -> Self {
         for byte in value.as_ref().iter() {
             use crate::formatter::parse_byte_to_hex;


### PR DESCRIPTION
Hi, I have implemented a convenience method that will help trim whitespaces when the user may need them.

There are cases when the response comes with some \r\n, which are not really necessary. Using this method, those bytes will be skipped, and the user only needs to think about the message.

Let's assume a message: `\r\nAT+CPIN: READY\r\n\r\nOK\r\n`, if I want to parse this when I use the library, I need to take care of putting those \r\n. Using the trim_whitespace methods, the strings will be simplified, and the headaches of checking the whitespaces will be gone.

Now the library performs the `trim_space`, maybe that can be replaced with the 'trim_whitespaces'.